### PR TITLE
feat: 添加 YouTube 字幕提取支持

### DIFF
--- a/content-scripts/youtube.js
+++ b/content-scripts/youtube.js
@@ -1,0 +1,216 @@
+// YouTube content script
+
+(function() {
+  'use strict';
+
+  console.log('[Subtitle Extractor] YouTube content script loaded');
+
+  let videoInfo = null;
+  let capturedSubtitles = [];
+
+  // Inject the interceptor script into page context ASAP
+  function injectScript() {
+    const script = document.createElement('script');
+    script.src = chrome.runtime.getURL('injected/youtube-injector.js');
+    script.onload = function() {
+      this.remove();
+      console.log('[Subtitle Extractor] Injector script loaded');
+    };
+    (document.head || document.documentElement).appendChild(script);
+  }
+
+  // Inject immediately
+  injectScript();
+
+  // Listen for messages from injected script
+  window.addEventListener('message', (event) => {
+    if (event.source !== window) return;
+    if (!event.data?.source?.startsWith('subtitle-extractor-yt-injector')) return;
+
+    const { type, data } = event.data;
+
+    if (type === 'VIDEO_INFO' || type === 'VIDEO_INFO_READY') {
+      videoInfo = data;
+      console.log('[Subtitle Extractor] Received video info:', data?.title);
+    }
+
+    if (type === 'SUBTITLE_CAPTURED') {
+      capturedSubtitles.push(data);
+      console.log('[Subtitle Extractor] Subtitle captured:', data.language, 'Total:', capturedSubtitles.length);
+
+      // Show notification
+      showNotification(`字幕已捕获: ${data.language}`);
+    }
+
+    if (type === 'CAPTURED_SUBTITLES') {
+      capturedSubtitles = data || [];
+    }
+  });
+
+  // Show a toast notification on the page
+  function showNotification(message) {
+    const existing = document.getElementById('subtitle-extractor-toast');
+    if (existing) existing.remove();
+
+    const toast = document.createElement('div');
+    toast.id = 'subtitle-extractor-toast';
+    toast.style.cssText = `
+      position: fixed;
+      top: 70px;
+      right: 20px;
+      background: #4CAF50;
+      color: white;
+      padding: 12px 20px;
+      border-radius: 8px;
+      z-index: 999999;
+      font-family: Arial, sans-serif;
+      font-size: 14px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+      animation: slideIn 0.3s ease;
+    `;
+    toast.textContent = message;
+
+    // Add animation style
+    const style = document.createElement('style');
+    style.textContent = `
+      @keyframes slideIn {
+        from { transform: translateX(100%); opacity: 0; }
+        to { transform: translateX(0); opacity: 1; }
+      }
+    `;
+    document.head.appendChild(style);
+
+    document.body.appendChild(toast);
+
+    setTimeout(() => {
+      toast.style.opacity = '0';
+      toast.style.transition = 'opacity 0.3s';
+      setTimeout(() => toast.remove(), 300);
+    }, 3000);
+  }
+
+  // Request video info from injected script
+  function requestVideoInfo() {
+    window.postMessage({
+      source: 'subtitle-extractor-yt-content',
+      type: 'GET_VIDEO_INFO'
+    }, '*');
+  }
+
+  // Request captured subtitles
+  function requestCapturedSubtitles() {
+    window.postMessage({
+      source: 'subtitle-extractor-yt-content',
+      type: 'GET_CAPTURED_SUBTITLES'
+    }, '*');
+  }
+
+  // Get current status for popup
+  function getStatus() {
+    return {
+      platform: 'youtube',
+      videoInfo: videoInfo,
+      hasSubtitles: videoInfo?.captionTracks?.length > 0,
+      subtitleList: videoInfo?.captionTracks?.map(t => ({
+        lan: t.languageCode,
+        lan_doc: t.name || t.languageCode
+      })) || [],
+      capturedCount: capturedSubtitles.length,
+      capturedLanguages: capturedSubtitles.map(s => s.language)
+    };
+  }
+
+  // Format captured subtitles for export
+  function formatSubtitles(subtitleData) {
+    if (!subtitleData?.data?.events) return [];
+
+    return subtitleData.data.events
+      .filter(e => e.segs && e.segs.length > 0)
+      .map(event => ({
+        start: (event.tStartMs || 0) / 1000,
+        end: ((event.tStartMs || 0) + (event.dDurationMs || 0)) / 1000,
+        text: event.segs.map(s => s.utf8 || '').join('').trim()
+      }))
+      .filter(s => s.text);
+  }
+
+  // Export subtitles to DOM
+  function exportToDOM(language) {
+    const subtitle = capturedSubtitles.find(s => s.language === language) || capturedSubtitles[0];
+
+    if (!subtitle) {
+      return { success: false, error: '没有找到捕获的字幕，请确保已开启字幕并播放视频' };
+    }
+
+    const formattedSubtitles = formatSubtitles(subtitle);
+
+    if (formattedSubtitles.length === 0) {
+      return { success: false, error: '字幕数据为空' };
+    }
+
+    const exportData = {
+      platform: 'youtube',
+      videoId: videoInfo?.videoId,
+      title: videoInfo?.title,
+      author: videoInfo?.author,
+      language: subtitle.language,
+      extractedAt: new Date().toISOString(),
+      subtitles: formattedSubtitles
+    };
+
+    // Write to DOM using shared function
+    if (typeof writeSubtitlesToDOM === 'function') {
+      writeSubtitlesToDOM(exportData);
+    } else {
+      // Fallback
+      let container = document.getElementById('subtitle-extractor-data');
+      if (!container) {
+        container = document.createElement('div');
+        container.id = 'subtitle-extractor-data';
+        container.style.display = 'none';
+        document.body.appendChild(container);
+      }
+      container.setAttribute('data-subtitles', JSON.stringify(exportData));
+    }
+
+    console.log('[Subtitle Extractor] Exported', formattedSubtitles.length, 'subtitle entries');
+    return { success: true, count: formattedSubtitles.length };
+  }
+
+  // Listen for messages from popup
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    console.log('[Subtitle Extractor] Received message:', message.type);
+
+    if (message.type === 'GET_STATUS') {
+      // Request fresh data from injector
+      requestVideoInfo();
+      requestCapturedSubtitles();
+
+      // Wait a bit for responses
+      setTimeout(() => {
+        sendResponse(getStatus());
+      }, 300);
+
+      return true; // Keep channel open
+    }
+
+    if (message.type === 'EXTRACT_SUBTITLE') {
+      const result = exportToDOM(message.language);
+      sendResponse(result);
+      return true;
+    }
+
+    if (message.type === 'REFRESH_INFO') {
+      requestVideoInfo();
+      sendResponse({ success: true });
+      return true;
+    }
+  });
+
+  // Initial request after a delay
+  setTimeout(() => {
+    requestVideoInfo();
+  }, 1000);
+
+  console.log('[Subtitle Extractor] YouTube content script initialized');
+})();

--- a/injected/youtube-injector.js
+++ b/injected/youtube-injector.js
@@ -1,0 +1,233 @@
+// YouTube XHR Interceptor - runs in page context
+// Intercepts subtitle requests made by YouTube player
+
+(function() {
+  'use strict';
+
+  console.log('[Subtitle Extractor] YouTube injector loaded');
+
+  // Storage for captured subtitles
+  window.__ytSubtitleData = {
+    videoInfo: null,
+    capturedSubtitles: [],
+    lastCaptureTime: null
+  };
+
+  // Save original XHR methods
+  const originalXHROpen = XMLHttpRequest.prototype.open;
+  const originalXHRSend = XMLHttpRequest.prototype.send;
+
+  // Intercept XMLHttpRequest.open
+  XMLHttpRequest.prototype.open = function(method, url, ...args) {
+    this._requestUrl = url;
+    this._requestMethod = method;
+    return originalXHROpen.apply(this, [method, url, ...args]);
+  };
+
+  // Intercept XMLHttpRequest.send
+  XMLHttpRequest.prototype.send = function(...args) {
+    const url = this._requestUrl;
+
+    // Check if this is a timedtext (subtitle) request
+    if (url && typeof url === 'string' && url.includes('timedtext')) {
+      console.log('[Subtitle Extractor] Intercepted timedtext request:', url.substring(0, 100));
+
+      this.addEventListener('load', function() {
+        try {
+          const responseText = this.responseText;
+          console.log('[Subtitle Extractor] Response received, status:', this.status, 'length:', responseText?.length);
+
+          if (this.status === 200 && responseText && responseText.length > 0) {
+            // Parse the subtitle data
+            let subtitleData = null;
+
+            // Try JSON format (json3)
+            if (url.includes('fmt=json3') || responseText.trim().startsWith('{')) {
+              try {
+                subtitleData = JSON.parse(responseText);
+                console.log('[Subtitle Extractor] Parsed JSON, events:', subtitleData.events?.length);
+              } catch (e) {
+                console.log('[Subtitle Extractor] JSON parse failed, trying XML');
+              }
+            }
+
+            // Try XML format
+            if (!subtitleData && responseText.includes('<?xml')) {
+              subtitleData = parseXMLSubtitles(responseText);
+            }
+
+            // Store the captured data
+            if (subtitleData) {
+              const captureInfo = {
+                url: url,
+                timestamp: Date.now(),
+                format: subtitleData.events ? 'json3' : 'xml',
+                data: subtitleData,
+                language: extractLanguageFromUrl(url)
+              };
+
+              window.__ytSubtitleData.capturedSubtitles.push(captureInfo);
+              window.__ytSubtitleData.lastCaptureTime = Date.now();
+
+              console.log('[Subtitle Extractor] Subtitle captured successfully!', captureInfo.language);
+
+              // Notify content script
+              window.postMessage({
+                source: 'subtitle-extractor-yt-injector',
+                type: 'SUBTITLE_CAPTURED',
+                data: captureInfo
+              }, '*');
+            }
+          } else {
+            console.log('[Subtitle Extractor] Empty or failed response');
+          }
+        } catch (error) {
+          console.error('[Subtitle Extractor] Error processing response:', error);
+        }
+      });
+    }
+
+    return originalXHRSend.apply(this, args);
+  };
+
+  // Parse XML subtitle format
+  function parseXMLSubtitles(xmlText) {
+    try {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(xmlText, 'text/xml');
+      const textElements = doc.querySelectorAll('text');
+
+      const events = [];
+      textElements.forEach(el => {
+        const start = parseFloat(el.getAttribute('start') || '0') * 1000;
+        const dur = parseFloat(el.getAttribute('dur') || '0') * 1000;
+        const text = el.textContent || '';
+
+        if (text.trim()) {
+          events.push({
+            tStartMs: start,
+            dDurationMs: dur,
+            segs: [{ utf8: decodeHTMLEntities(text) }]
+          });
+        }
+      });
+
+      return { events };
+    } catch (e) {
+      console.error('[Subtitle Extractor] XML parse error:', e);
+      return null;
+    }
+  }
+
+  // Decode HTML entities
+  function decodeHTMLEntities(text) {
+    const textarea = document.createElement('textarea');
+    textarea.innerHTML = text;
+    return textarea.value;
+  }
+
+  // Extract language code from URL
+  function extractLanguageFromUrl(url) {
+    const match = url.match(/[&?]lang=([^&]+)/);
+    return match ? match[1] : 'unknown';
+  }
+
+  // Get video info from page
+  function getVideoInfo() {
+    try {
+      if (window.ytInitialPlayerResponse) {
+        const response = window.ytInitialPlayerResponse;
+        const videoDetails = response.videoDetails || {};
+        const captions = response.captions?.playerCaptionsTracklistRenderer;
+
+        return {
+          videoId: videoDetails.videoId,
+          title: videoDetails.title,
+          author: videoDetails.author,
+          lengthSeconds: videoDetails.lengthSeconds,
+          captionTracks: captions?.captionTracks?.map(t => ({
+            languageCode: t.languageCode,
+            name: t.name?.simpleText || t.name?.runs?.[0]?.text || '',
+            baseUrl: t.baseUrl
+          })) || []
+        };
+      }
+      return null;
+    } catch (e) {
+      console.error('[Subtitle Extractor] Error getting video info:', e);
+      return null;
+    }
+  }
+
+  // Listen for messages from content script
+  window.addEventListener('message', (event) => {
+    if (event.source !== window) return;
+    if (event.data?.source !== 'subtitle-extractor-yt-content') return;
+
+    const { type } = event.data;
+
+    if (type === 'GET_VIDEO_INFO') {
+      const info = getVideoInfo();
+      window.__ytSubtitleData.videoInfo = info;
+
+      window.postMessage({
+        source: 'subtitle-extractor-yt-injector',
+        type: 'VIDEO_INFO',
+        data: info
+      }, '*');
+    }
+
+    if (type === 'GET_CAPTURED_SUBTITLES') {
+      window.postMessage({
+        source: 'subtitle-extractor-yt-injector',
+        type: 'CAPTURED_SUBTITLES',
+        data: window.__ytSubtitleData.capturedSubtitles
+      }, '*');
+    }
+
+    if (type === 'CLEAR_CAPTURED') {
+      window.__ytSubtitleData.capturedSubtitles = [];
+      console.log('[Subtitle Extractor] Cleared captured subtitles');
+    }
+  });
+
+  // Auto-send video info when ready
+  const checkReady = setInterval(() => {
+    if (window.ytInitialPlayerResponse) {
+      clearInterval(checkReady);
+      const info = getVideoInfo();
+      if (info) {
+        window.__ytSubtitleData.videoInfo = info;
+        window.postMessage({
+          source: 'subtitle-extractor-yt-injector',
+          type: 'VIDEO_INFO_READY',
+          data: info
+        }, '*');
+        console.log('[Subtitle Extractor] Video info ready:', info.title);
+      }
+    }
+  }, 500);
+
+  // Stop checking after 30 seconds
+  setTimeout(() => clearInterval(checkReady), 30000);
+
+  // Watch for SPA navigation
+  document.addEventListener('yt-navigate-finish', () => {
+    console.log('[Subtitle Extractor] Navigation detected, clearing old data');
+    window.__ytSubtitleData.capturedSubtitles = [];
+
+    setTimeout(() => {
+      const info = getVideoInfo();
+      if (info) {
+        window.__ytSubtitleData.videoInfo = info;
+        window.postMessage({
+          source: 'subtitle-extractor-yt-injector',
+          type: 'VIDEO_INFO_READY',
+          data: info
+        }, '*');
+      }
+    }, 1000);
+  });
+
+  console.log('[Subtitle Extractor] XHR interceptor installed');
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Bilibili Subtitle Extractor",
-  "version": "1.1.0",
-  "description": "Extract subtitles from Bilibili videos for summarization and analysis",
+  "name": "Subtitle Extractor",
+  "version": "1.2.0",
+  "description": "Extract subtitles from Bilibili and YouTube videos",
   "permissions": [
     "activeTab",
     "scripting"
@@ -11,7 +11,9 @@
     "https://www.bilibili.com/*",
     "https://api.bilibili.com/*",
     "https://*.bilivideo.com/*",
-    "https://*.hdslb.com/*"
+    "https://*.hdslb.com/*",
+    "https://www.youtube.com/*",
+    "https://youtube.com/*"
   ],
   "background": {
     "service_worker": "background.js"
@@ -21,12 +23,17 @@
       "matches": ["https://www.bilibili.com/video/*"],
       "js": ["content-scripts/shared.js", "content-scripts/bilibili.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://www.youtube.com/watch*", "https://youtube.com/watch*"],
+      "js": ["content-scripts/shared.js", "content-scripts/youtube.js"],
+      "run_at": "document_start"
     }
   ],
   "web_accessible_resources": [
     {
-      "resources": ["injected/bilibili-injector.js"],
-      "matches": ["https://www.bilibili.com/*"]
+      "resources": ["injected/bilibili-injector.js", "injected/youtube-injector.js"],
+      "matches": ["https://www.bilibili.com/*", "https://www.youtube.com/*"]
     }
   ],
   "action": {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -9,7 +9,7 @@
 <body>
   <div class="container">
     <header>
-      <h1>B站字幕提取</h1>
+      <h1>字幕提取器</h1>
     </header>
 
     <main>


### PR DESCRIPTION
## Summary

- 添加 YouTube 字幕拦截功能，通过 XHR 拦截方案成功捕获播放器请求的字幕数据
- 更新插件支持双平台（B站 + YouTube）

## 技术方案

使用 **XHR 拦截**而非直接 API 请求：

| 方案 | 结果 |
|------|------|
| 直接请求 timedtext API | ❌ 返回空（需要 POT 参数） |
| Innertube API | ❌ 400 错误 |
| **XHR 拦截** | ✅ 成功 |

## 改动内容

- `manifest.json` - 添加 YouTube 权限和内容脚本配置
- `injected/youtube-injector.js` - 页面上下文 XHR 拦截器
- `content-scripts/youtube.js` - YouTube 内容脚本
- `popup/popup.html` & `popup/popup.js` - 支持双平台显示

## 测试结果

✅ 成功捕获 181 条字幕数据：

```javascript
{
  platform: 'youtube',
  videoId: 'aa8GL86ZszQ',
  title: 'Chrome DevTools MCP Server Solves a BIG Problem',
  author: 'DesignCourse',
  language: 'en',
  subtitles: (181)
}
```

## Test plan

- [x] 打开 YouTube 视频页面
- [x] 开启字幕并播放视频
- [x] 确认页面右上角显示"字幕已捕获"提示
- [x] 点击插件图标确认显示已捕获数量
- [x] 点击"提取字幕"按钮
- [x] 在控制台验证字幕数据完整性

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)