### PR TITLE
fix: 修复 YouTube 字幕重复捕获问题

### DIFF
--- a/content-scripts/youtube.js
+++ b/content-scripts/youtube.js
@@ -70,7 +70,11 @@
     }
 
     if (type === 'CAPTURED_SUBTITLES') {
-      capturedSubtitles = data || [];
+      // 只有在本地没有数据时才使用 injector 的数据，避免覆盖
+      if (capturedSubtitles.length === 0 && data && data.length > 0) {
+        capturedSubtitles = data;
+        console.log('[Subtitle Extractor] Synced subtitles from injector:', data.length);
+      }
     }
   });
 
@@ -220,10 +224,10 @@
         return true;
       }
 
-      // 否则请求新数据并等待
+      // 否则请求新的视频信息（不请求字幕，本地已有）
       console.log('[Subtitle Extractor] Requesting fresh video info');
       requestVideoInfo();
-      requestCapturedSubtitles();
+      // 注意：不调用 requestCapturedSubtitles()，避免覆盖本地已捕获的字幕
 
       // 等待 injector 响应，最多等 2 秒
       let attempts = 0;

--- a/content-scripts/youtube.js
+++ b/content-scripts/youtube.js
@@ -34,11 +34,14 @@
     const { type, data } = event.data;
 
     if (type === 'VIDEO_INFO' || type === 'VIDEO_INFO_READY') {
-      // 检测是否切换了视频
-      if (data?.videoId && data.videoId !== currentVideoId) {
-        console.log('[Subtitle Extractor] Video changed, clearing old data');
+      // 检测是否切换了视频（只有在已有 currentVideoId 时才清空）
+      if (data?.videoId && currentVideoId && data.videoId !== currentVideoId) {
+        console.log('[Subtitle Extractor] Video changed from', currentVideoId, 'to', data.videoId, ', clearing old data');
         capturedSubtitles = []; // 清空旧字幕
         lastNotification = { language: null, time: 0 }; // 重置防抖
+      }
+      // 更新 currentVideoId
+      if (data?.videoId) {
         currentVideoId = data.videoId;
       }
       videoInfo = data;

--- a/content-scripts/youtube.js
+++ b/content-scripts/youtube.js
@@ -7,6 +7,7 @@
 
   let videoInfo = null;
   let capturedSubtitles = [];
+  let currentVideoId = null; // 追踪当前视频ID，用于检测视频切换
 
   // 防抖：记录最近通知的语言和时间
   let lastNotification = { language: null, time: 0 };
@@ -33,6 +34,13 @@
     const { type, data } = event.data;
 
     if (type === 'VIDEO_INFO' || type === 'VIDEO_INFO_READY') {
+      // 检测是否切换了视频
+      if (data?.videoId && data.videoId !== currentVideoId) {
+        console.log('[Subtitle Extractor] Video changed, clearing old data');
+        capturedSubtitles = []; // 清空旧字幕
+        lastNotification = { language: null, time: 0 }; // 重置防抖
+        currentVideoId = data.videoId;
+      }
       videoInfo = data;
       console.log('[Subtitle Extractor] Received video info:', data?.title);
     }

--- a/injected/youtube-injector.js
+++ b/injected/youtube-injector.js
@@ -305,4 +305,41 @@
   });
 
   console.log('[Subtitle Extractor] XHR interceptor installed');
+
+  // 检查字幕是否已开启，如果是则触发重新加载
+  function triggerSubtitleReloadIfNeeded() {
+    const player = document.querySelector('#movie_player');
+    if (!player || typeof player.isSubtitlesOn !== 'function') {
+      console.log('[Subtitle Extractor] Player not ready, will retry');
+      return false;
+    }
+
+    // 如果字幕已开启但我们没有捕获到数据
+    if (player.isSubtitlesOn() && window.__ytSubtitleData.capturedSubtitles.length === 0) {
+      console.log('[Subtitle Extractor] Subtitles already on, triggering reload');
+
+      // 关闭再打开字幕来触发新请求
+      player.toggleSubtitlesOn(); // 关闭
+      setTimeout(() => {
+        player.toggleSubtitlesOn(); // 打开
+        console.log('[Subtitle Extractor] Subtitle reload triggered');
+      }, 300);
+
+      return true;
+    }
+
+    return false;
+  }
+
+  // 页面加载后检查字幕状态
+  setTimeout(() => {
+    triggerSubtitleReloadIfNeeded();
+  }, 2000);
+
+  // 如果 2 秒后还没成功，再试一次
+  setTimeout(() => {
+    if (window.__ytSubtitleData.capturedSubtitles.length === 0) {
+      triggerSubtitleReloadIfNeeded();
+    }
+  }, 5000);
 })();

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -58,7 +58,14 @@ async function checkStatus() {
     displayStatus(response);
   } catch (error) {
     console.error('Error checking status:', error);
-    showError('无法检测视频信息，请刷新页面后重试');
+
+    // 检测是否是连接错误（content script 未加载）
+    if (error.message?.includes('Could not establish connection') ||
+        error.message?.includes('Receiving end does not exist')) {
+      showError('插件未加载，请刷新页面 (Ctrl+R / Cmd+R)');
+    } else {
+      showError('无法检测视频信息，请刷新页面后重试');
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

修复 YouTube 字幕捕获时的重复问题：
- 语言选项重复显示
- Toast 提示重复弹出

## 改动内容

### `injected/youtube-injector.js`
- 存储字幕前检查是否已存在相同语言
- 存在则更新记录，而非新增
- 只有新捕获的字幕才发送通知

### `content-scripts/youtube.js`
- 添加防抖变量 `lastNotification`
- 3秒内同语言不重复提示
- `capturedSubtitles` 数组也添加去重逻辑

## Test plan

- [ ] 打开 YouTube 视频，多次开关字幕
- [ ] 确认语言下拉框不再重复
- [ ] 确认 Toast 提示不再重复弹出
- [ ] 切换不同语言时仍能正常显示新提示

Fixes #3, Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)